### PR TITLE
Add function to the correct prototype.

### DIFF
--- a/ad/graph.js
+++ b/ad/graph.js
@@ -84,7 +84,7 @@ TensorNode.prototype.copy = function(other) {
 	this.x = other.x.clone();
 	this.dx = other.dx.clone();
 };
-Tensor.prototype.clone = function() {
+TensorNode.prototype.clone = function() {
 	var node = Object.create(Tensor.prototype);
 	node.copy(this);
 	return node;


### PR DESCRIPTION
Running the following:

``` js
var nn = require('adnn/nn');
var Tensor = require('adnn/tensor');
var net = nn.linear(10, 10);
net.eval(new Tensor([10]));
```

Gives something like:

```
// adnn/tensor.js:12
//          tgt.set(src, offset);
//             ^

// TypeError: Cannot read property 'set' of undefined
```

This fixes that.
