### PR TITLE
Optimize handling of arguments.

### DIFF
--- a/ad/func.js
+++ b/ad/func.js
@@ -119,7 +119,11 @@ function newFunction(opts) {
 	return function() {
 		var output = forward.apply(null, arguments);
 		var parents = getParents.apply(null, arguments);
-		var inputs = Array.prototype.slice.call(arguments);
+		// https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#3-managing-arguments
+		var inputs = new Array(arguments.length);
+		for (var i = 0; i < inputs.length; ++i) {
+			inputs[i] = arguments[i];
+		}
 		var n = parents.length;
 		if (n === 0) {
 			return output;


### PR DESCRIPTION
While profiling webppl this anonymous function showed up as been reasonably expensive.

![before](https://cloud.githubusercontent.com/assets/9109012/19446493/eca6f032-9490-11e6-9b43-026c5eda57ac.png)

This change gets the self time down from about 4% (see above) to about 0.4%. This translates to about a 10% reduction in running time for the program I was profiling.

It's not a big improvement, and it's an ugly change, so I understand if you don't want to merge it!

(PS: the function at the top of that screen grab is addressed by #10.)
