### PR TITLE
Bump sweet.js to 2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "dritchie",
   "license": "MIT",
   "dependencies": {
-    "sweet.js": "^0.7.4"
+    "sweet.js": "^2.2.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I'm working on something that currently requires running a browserified copy of webppl inside of a V8 engine that runs in R.

Recently, the browserified package stopped running -- V8 complains about `fs.realpathSync` being undefined. This problem is solved by upgrading the sweet.js version that adnn depends on. (I have no idea why this problem is only surfacing now, since we've been using 0.7.4 for a long time, but I've already spent a few hours investigating and am no closer to an answer).

adnn doesn't seem obviously broken by this change -- I ran `test/linreg.js` with no issue and also tried this out with webppl and the tests all passed -- but I might be missing something.