### PR TITLE
Add backwards pass for cholesky.

### DIFF
--- a/ad/README.md
+++ b/ad/README.md
@@ -62,6 +62,7 @@ adnn comes with a large number of built-in AD primitives:
   - **`ad.tensor.inverse(x)`**: Returns the inverse of the matrix `x`.
   - **`ad.tensor.determinant(x)`**: Returns the determinant of the matrix `x`.
   - **`ad.tensor.dot(x, y)`**: Returns the inner product of the matrices `x` and `y`.
+  - **`ad.tensor.cholesky(x)`**: Returns the [Cholesky decomposition](https://en.wikipedia.org/wiki/Cholesky_decomposition) of the matrix `x`.
 - **Miscellaneous**
   - **`ad.tensor.softmax(x)`**: Compute the [Softmax](https://en.wikipedia.org/wiki/Softmax_function) function for a tensor `x`.
 

--- a/tensor.js
+++ b/tensor.js
@@ -508,6 +508,22 @@ Tensor.prototype.cholesky = function() {
   return L;
 };
 
+// Return a copy of a matrix with the elements above the main diagonal
+// zeroed.
+Tensor.prototype.tril = function() {
+	var a = this;
+	assert.ok((a.rank === 2) && (a.dims[0] === a.dims[1]),
+		  'tril is only defined for square matrices.');
+
+	var n = a.dims[0];
+	var ret = new Tensor([n, n]);
+	for (var i = 0; i < n; i++) {
+		for (var j = 0; j <= i; j++) {
+			ret.data[i * n + j] = a.data[i * n + j];
+		}
+	}
+	return ret;
+};
 
 module.exports = Tensor;
 


### PR DESCRIPTION
This would be useful in webppl. It would allow us to support the reparameterization trick for the multivariate Gaussian.

I've checked this with finite differences, and it appears correct. Here's [the test code](https://gist.github.com/null-a/16cc5a5cf08c4081661d5fab19448621) and sample output.

For reference, here's a recent [paper](https://arxiv.org/abs/1602.07527) on this. I've not looked at it closely, but my impression is that the methods described might be more efficient, but are probably trickier for us to implement.

