### PR TITLE
Matrix Diagonal Incorrect Formula

### DIFF
--- a/tensor.js
+++ b/tensor.js
@@ -320,7 +320,7 @@ Tensor.prototype.diagonal = function() {
   var n = this.dims[0];
   var y = new Tensor([n, n]);
   for (var i = 0; i < n; i++) {
-    y.data[i * (n + 1)] = this.data[i];
+    y.data[i * (n + 1)] = this.data[i * (n + 1)];
   }
   return y;
 };


### PR DESCRIPTION
Diagonal is calculated wrong; it currently only returns the first row as the diagonal entries.

There are unit tests in the torch branch that will be merged eventually, but this is to fix it in the current javascript tensor in case anyone needs it.