### PR TITLE
options.shuffle

### DIFF
--- a/opt/optimize.js
+++ b/opt/optimize.js
@@ -72,8 +72,9 @@ function adTrain(fn, trainingData, lossFn, options) {
 	});
 
 	var batchSize = options.batchSize;
+	var shuffle = options.shuffle;
 
-	var idx;
+	var idx = -1;
 	var singleFn = makeOptimizable(function() {
 		var trainingDatum = trainingData[idx];
 		var rets = fn(trainingDatum.input);
@@ -87,7 +88,9 @@ function adTrain(fn, trainingData, lossFn, options) {
 		var gradients;
 		var parameters;
 		for (var i = 0; i < batchSize; i++) {
-			idx = Math.floor(Math.random() * trainingData.length);
+			idx = shuffle === false ?
+				(idx + 1) % trainingData.length : 
+				Math.floor(Math.random() * trainingData.length);
 			var rets = singleFn();
 			if (gradients === undefined) {
 				gradients = rets.gradients;


### PR DESCRIPTION
training batches are chosen randomly from `trainingData`. setting `options.shuffle` to `false` will disable that, and instead draw entries from trainingData in the provided order.

if at end of `trainingData`, start again at index 0 to draw the next trainingDatum